### PR TITLE
encrypt only the value if key is an empty string

### DIFF
--- a/bin/travis-encrypt-cli.js
+++ b/bin/travis-encrypt-cli.js
@@ -43,17 +43,20 @@ var argv = optimist
             throw 'insufficient github credentials';
         }
 
-        if (!(args.hasOwnProperty('n') && args.hasOwnProperty('v')) &&
-            !args.hasOwnProperty('j')
+        if (!(args.hasOwnProperty('v')) && !args.hasOwnProperty('j')
         ) {
-            throw 'must provide a key/value pair or a json file of variables to encrypt';
+            throw 'must provide a value or a json file of variables to encrypt';
         }
     })
     .argv;
 
 var displayEncryptedValue = function (slug, name, value, username, password) {
-    return encrypt(slug, (name === true ? '' : name + '=') + value, username, password, function (err, res) {
-        console.log('# ' + name.grey);
+    /* if name is provided, then prepend to value as a name / value pair */
+    if (name) {
+      value = name + '=' + value;
+    }
+    return encrypt(slug, value, username, password, function (err, res) {
+        console.log('# ' + (name || 'undefined').grey);
         if (err) {
             console.warn(err.toString().red);
         } else {


### PR DESCRIPTION
this pull request only modifies one line in your code to change the behavior if key is an empty string

```
$ ## example usage with empty key string
$ travis-encrypt -r kaizhu256/utility2 -k "" -v "heroku_api_key_secret"
# undefined
+UOJknUje0te1+54BFtDQi+1jFBTDfFI7qYSV+tcDMkCeQJ7K/lh4y45c8w+I/OE0BL7eyL1MowiMf5oQnSlDg==
```
