### PR TITLE
option 1 - encrypt only the value if key is an empty string

### DIFF
--- a/bin/travis-encrypt-cli.js
+++ b/bin/travis-encrypt-cli.js
@@ -13,7 +13,7 @@ var argv = optimist
     .alias('r', 'repo')
     .alias('r', 'repository')
     .describe('r', 'repository slug')
-    
+
     .string('k')
     .alias('k', 'key')
     .alias('k', 'name')
@@ -52,7 +52,7 @@ var argv = optimist
     .argv;
 
 var displayEncryptedValue = function (slug, name, value, username, password) {
-    return encrypt(slug, name + '=' + value, username, password, function (err, res) {
+    return encrypt(slug, (name === true ? '' : name + '=') + value, username, password, function (err, res) {
         console.log('# ' + name.grey);
         if (err) {
             console.warn(err.toString().red);


### PR DESCRIPTION
this first option is simple and only modifies one line in your code to change the behavior if key is an empty string

```
$ ## example usage with empty key string
$ travis-encrypt -r kaizhu256/utility2 -k "" -v "heroku_api_key_secret"
# undefined
+UOJknUje0te1+54BFtDQi+1jFBTDfFI7qYSV+tcDMkCeQJ7K/lh4y45c8w+I/OE0BL7eyL1MowiMf5oQnSlDg==
```
