### PR TITLE
option 2 - make key param optional in travis-encrypt

### DIFF
--- a/bin/travis-encrypt-cli.js
+++ b/bin/travis-encrypt-cli.js
@@ -43,17 +43,20 @@ var argv = optimist
             throw 'insufficient github credentials';
         }
 
-        if (!(args.hasOwnProperty('n') && args.hasOwnProperty('v')) &&
-            !args.hasOwnProperty('j')
+        if (!(args.hasOwnProperty('v')) && !args.hasOwnProperty('j')
         ) {
-            throw 'must provide a key/value pair or a json file of variables to encrypt';
+            throw 'must provide a value or a json file of variables to encrypt';
         }
     })
     .argv;
 
 var displayEncryptedValue = function (slug, name, value, username, password) {
-    return encrypt(slug, (name === true ? '' : name + '=') + value, username, password, function (err, res) {
-        console.log('# ' + name.grey);
+    /* if name is provided, then prepend to value as a name / value pair */
+    if (name) {
+      value = name + '=' + value;
+    }
+    return encrypt(slug, value, username, password, function (err, res) {
+        console.log('# ' + (name || 'undefined').grey);
         if (err) {
             console.warn(err.toString().red);
         } else {


### PR DESCRIPTION
second option is a more involved patch, which makes the key param entirely optional

```
$ ## example usage with no key param
$ travis-encrypt -r kaizhu256/utility2 -v "heroku_api_key_secret"
# undefined
+UOJknUje0te1+54BFtDQi+1jFBTDfFI7qYSV+tcDMkCeQJ7K/lh4y45c8w+I/OE0BL7eyL1MowiMf5oQnSlDg==
```
