### PR TITLE
Add option to save to .travis.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ npm:
 
 ## CLI
 ```bash
-Usage: travis-encrypt -r [repository slug] -u [username] -p [password]
+Usage: travis-encrypt -r [repository slug] -u [username] -p [password] -a [key]
 
 Options:
   -r, --repo        repository slug                                                   [string]
   -u, --username    github username associated with the pro travis repo               [string]
   -p, --password    github password for the user associated with the pro travis repo  [string]
+  -a, --add         adds it to .travis.yml under key (default: env.global)            [string]
 ```
 
 ##### args
@@ -58,6 +59,12 @@ node_js:
 env:
     global:
         - secure: "XqJtWxYjtjhRO3LzC/iBGLawDP+f/dL6kcUfDzDJPSKhdnXIRQgBE65g58hf1bPh4YowxuyPUnpK5pq6+frYQ6zNsW0AWBMa2dUP1FdSIxdCJNa3UHlMLYhqqECuVvev9A9NCijKBkuOOA+OvNgq9NIQsiS4g+dsaAlpuE72MYc="
+```
+
+##### using --add to populate .travis.yml
+```bash
+travis-encrypt --add -r pwmckenna/node-travis-encrypt ENV1=VALUE1 ENV2=VALUE2
+> Wrote 2 blob(s) to .travis.yml
 ```
 
 ## Module

--- a/package.json
+++ b/package.json
@@ -24,10 +24,13 @@
   "bugs": "https://github.com/pwmckenna/node-travis-encrypt/issues",
   "dependencies": {
     "colors": "~0.6.0-1",
+    "deep-property": "^1.1.0",
+    "read-yaml": "^1.0.0",
     "split": "~0.3.0",
     "travis-ci": "^2.0.0",
     "ursa": "~0.8.0",
-    "yargs": "~1.2.2"
+    "write-yaml": "^0.1.2",
+    "yargs": "^1.3.3"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
I like how the ruby travis thing can add the encrypted blobs to your `.travis.yml` automatically, when passing the `--add` option. I'd rather use node to do the job though.

This PR adds support for this feature. Let me know if you want anything changed.

Note: A little `--help` fix slipped in here, yargs was being a bit difficult, so the code didn't turn out too pretty though.