### PR TITLE
Update license to BSD-3-Clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     ".travis.yml"
   ],
   "author": "Patrick Williams <pwmckenna@gmail.com>",
-  "license": "BSD",
+  "license": "BSD-3-Clause",
   "readmeFilename": "README.md",
   "main": "lib/travis-encrypt",
   "bin": {


### PR DESCRIPTION
the old license, `BSD`, gives this warning:

```
npm WARN package.json travis-encrypt@1.1.1 license should be a valid SPDX license expression
```

This is because there are [9 different BSD licenses](http://spdx.org/licenses/). I've changed it to BSD-3-Clause, which i'm going to guess is what you want.