### PR TITLE
Adding ability to write to a given key in .travis.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Options:
   -r, --repo        repository slug                                                   [string]
   -u, --username    github username associated with the pro travis repo               [string]
   -p, --password    github password for the user associated with the pro travis repo  [string]
-  -a, --add         adds it to .travis.yml under `env.global`                         [boolean]
+  -a, --add         add it to .travis.yml under the given key or `env.global`         [string]
 ```
 
 ##### args
@@ -65,6 +65,12 @@ env:
 ```bash
 travis-encrypt --add -r pwmckenna/node-travis-encrypt ENV1=VALUE1 ENV2=VALUE2
 > Wrote 2 blob(s) to .travis.yml
+```
+
+##### using --add to populate .travis.yml with Heroku deploy key
+```bash
+travis-encrypt --add deploy.api_key -r pwmckenna/node-travis-encrypt "<Heroku API key>"
+> Wrote 1 blob(s) to .travis.yml
 ```
 
 ## Module

--- a/tests/cli.test.js
+++ b/tests/cli.test.js
@@ -81,13 +81,40 @@ test('it can write given data to .travis.yml', function (t) {
     fs.readFileSync(source)
   );
 
-  spawn(['-r', 'pwmckenna/node-travis-encrypt', '--add', 'FOO=bar', 'BAR=foo'], {
+  spawn(['--add', '-r', 'pwmckenna/node-travis-encrypt', 'FOO=bar', 'BAR=foo'], {
     cwd: path.join(__dirname, 'fixtures')
   }, function (res) {
     t.equal(res.status, 0, 'status could should be 0');
     bufferContains(t, res.stdout, 'Wrote 2 blob(s)');
 
     var edited = fs.readFileSync(target);
+    bufferContains(t, edited, '- secure: ');
+
+    maybeUnlink(target);
+
+    t.end();
+  });
+});
+
+test('it can write given data to a key in .travis.yml', function (t) {
+  var fixturesDir = path.join(__dirname, 'fixtures');
+  var target = path.join(fixturesDir, '.travis.yml');
+  var source = path.join(fixturesDir, 'travis.original.yml');
+
+  maybeUnlink(target);
+  fs.writeFileSync(
+    target,
+    fs.readFileSync(source)
+  );
+
+  spawn(['-r', 'pwmckenna/node-travis-encrypt', '--add', 'addons.addTest', 'testing'], {
+    cwd: path.join(__dirname, 'fixtures')
+  }, function (res) {
+    t.equal(res.status, 0, 'status could should be 0');
+    bufferContains(t, res.stdout, 'Wrote 1 blob(s)');
+
+    var edited = fs.readFileSync(target);
+    bufferContains(t, edited, 'addTest:');
     bufferContains(t, edited, '- secure: ');
 
     maybeUnlink(target);


### PR DESCRIPTION
Thank you for this tool! It is very helpful when you don't want people with Node having to install the Travis CLI which requires Ruby.

However, when updating our Guide (http://donejs.com/place-my-order.html) to use it instead of Travis CLI I ran into the problem that it only allows to update the environment variables but it is also possible to encrypt other keys, e.g. the Heroku API key for automated deployment.

I added the option to pass a key name to the CLI (e.g. `--add deploy.api_key`). It should be mostly backwards compatible according to the documentation, e.g.

```
travis-encrypt --add -r pwmckenna/node-travis-encrypt ENV1=VALUE1 ENV2=VALUE2
```

But

```
travis-encrypt -r pwmckenna/node-travis-encrypt --add ENV1=VALUE1 ENV2=VALUE2
```

won't work because it will now try to use `ENV1=VALUE1` as the key.